### PR TITLE
Further invite/collab work

### DIFF
--- a/api/controllers/album.js
+++ b/api/controllers/album.js
@@ -2,6 +2,7 @@ const validate    = require('../../modules/modules').validate;
 const errors      = require('../../modules/modules').errors;
 const album       = require('../../data/models/models').album;
 const media       = require('../../data/models/models').media;
+const collaborator = require('../../data/models/models').collaborator;
 const utils       = require('../../modules/modules').utils;
 const jwt         = require('jsonwebtoken');
 const environment = process.env.NODE_ENV || 'development';
@@ -51,67 +52,78 @@ const getUsersAlbums = (req, res, next) => {
       if (retrieveErr) next(retrieveErr);
       else {
 
-        // Add cover_url to albums objects
-        media.retrieveUsersMedia(user_id, (retrieveMediaErr, mediaArr) => {
+        collaborator.retrieveCollabAlbums(user_id, (collabErr, collabArr) => {
 
-          if (retrieveMediaErr) next(retrieveMediaErr);
+          if (collabErr) next(collabErr);
           else {
 
-            albumsArr.forEach(albumObj => {
-
-              albumObj.album_id = parseInt(albumObj.album_id);
-              albumObj.user_id  = parseInt(albumObj.user_id);
-
-              if (albumObj.cover_id === null) {
-
-                if (mediaArr.length === 0) albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
+            albumsArr = albumsArr.concat(collabArr);
+            
+            // Add cover_url to albums objects
+            media.retrieveUsersMedia(user_id, (retrieveMediaErr, mediaArr) => {
+              
+              if (retrieveMediaErr) next(retrieveMediaErr);
+              else {
                 
-                for (let i = 0; i < mediaArr.length; i++) {
+                albumsArr.forEach(albumObj => {
                   
-                  if (mediaArr[i].albums.includes(albumObj.album_id)) {
-
-                    albumObj.cover_url = `${ serverHost }/users/${ mediaArr[i].user_id }/media/thumbnail/${ mediaArr[i].title }`;
-                    // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaArr[i].user_id }/${ mediaArr[i].title }.jpg`;
-                    i = mediaArr.length;
-
-                  } else albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
-
-                }
-
-              } else {
-
-                mediaArr.forEach(mediaObj => {
-
-                  if (albumObj.cover_id === mediaObj.media_id) {
-  
-                    albumObj.cover_url = `${ serverHost }/users/${ mediaObj.user_id }/media/thumbnail/${ mediaObj.title }`;
-                    // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaObj.user_id }/${ mediaObj.title }.jpg`;
-  
+                  albumObj.album_id = parseInt(albumObj.album_id);
+                  albumObj.user_id  = parseInt(albumObj.user_id);
+                  
+                  if (albumObj.cover_id === null) {
+                    
+                    if (mediaArr.length === 0) albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
+                    
+                    for (let i = 0; i < mediaArr.length; i++) {
+                      
+                      if (mediaArr[i].albums.includes(albumObj.album_id)) {
+                        
+                        albumObj.cover_url = `${ serverHost }/users/${ mediaArr[i].user_id }/media/thumbnail/${ mediaArr[i].title }`;
+                        // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaArr[i].user_id }/${ mediaArr[i].title }.jpg`;
+                        i = mediaArr.length;
+                        
+                      } else albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
+                      
+                    }
                   } else {
-  
-                    albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
-  
+                    
+                    mediaArr.forEach(mediaObj => {
+                      
+                      if (albumObj.cover_id === mediaObj.media_id) {
+                        
+                        albumObj.cover_url = `${ serverHost }/users/${ mediaObj.user_id }/media/thumbnail/${ mediaObj.title }`;
+                        // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaObj.user_id }/${ mediaObj.title }.jpg`;
+                        
+                      } else {
+                        
+                        albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
+                        
+                      }
+                      
+                    });
+                    
                   }
-  
+                  
+                  delete albumObj.cover_id;
+                  
                 });
-
-              }
-
-              delete albumObj.cover_id;
-
+                
+                if (isOwner || isAdmin) {
+                  
+                  // Send all albums.
+                  res.status(200).json(albumsArr);
+                  
+                } else {
+                  
+                  // Send public albums only.
+                  res.status(200).json(albumsArr.filter(albumObj => albumObj.access !== 'private'));
+                  
+                }
+                
+                
+              }  
+              
             });
-
-            if (isOwner || isAdmin) {
-
-              // Send all albums.
-              res.status(200).json(albumsArr);
-    
-            } else {
-        
-              // Send public albums only.
-              res.status(200).json(albumsArr.filter(albumObj => albumObj.access !== 'private'));
-    
-            }
 
           }
 

--- a/api/controllers/album.js
+++ b/api/controllers/album.js
@@ -7,7 +7,10 @@ const utils       = require('../../modules/modules').utils;
 const jwt         = require('jsonwebtoken');
 const environment = process.env.NODE_ENV || 'development';
 const serverHost  = utils.getEnvironmentHost(environment);
-const generateAlbumCover = require('../../modules/coverAlbum').generateAlbumCover
+const {
+  generateCoverUpdated,
+  genCoverPromiseArray
+} = require('../../modules/coverAlbum')
 
 const createAlbum = (req, res, next) => {
 
@@ -52,79 +55,26 @@ const getUsersAlbums = (req, res, next) => {
       if (retrieveErr) next(retrieveErr);
       else {
 
-        collaborator.retrieveCollabAlbums(user_id, (collabErr, collabArr) => {
+        collaborator.retrieveCollabAlbums(user_id, async (collabErr, collabArr) => {
 
           if (collabErr) next(collabErr);
           else {
 
             albumsArr = albumsArr.concat(collabArr);
-            
-            // Add cover_url to albums objects
-            media.retrieveUsersMedia(user_id, (retrieveMediaErr, mediaArr) => {
-              
-              if (retrieveMediaErr) next(retrieveMediaErr);
-              else {
-                
-                albumsArr.forEach(albumObj => {
-                  
-                  albumObj.album_id = parseInt(albumObj.album_id);
-                  albumObj.user_id  = parseInt(albumObj.user_id);
-                  
-                  if (albumObj.cover_id === null) {
-                    
-                    if (mediaArr.length === 0) albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
-                    
-                    for (let i = 0; i < mediaArr.length; i++) {
-                      
-                      if (mediaArr[i].albums.includes(albumObj.album_id)) {
-                        
-                        albumObj.cover_url = `${ serverHost }/users/${ mediaArr[i].user_id }/media/thumbnail/${ mediaArr[i].title }`;
-                        // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaArr[i].user_id }/${ mediaArr[i].title }.jpg`;
-                        i = mediaArr.length;
-                        
-                      } else albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
-                      
-                    }
-                  } else {
-                    
-                    mediaArr.forEach(mediaObj => {
-                      
-                      if (albumObj.cover_id === mediaObj.media_id) {
-                        
-                        albumObj.cover_url = `${ serverHost }/users/${ mediaObj.user_id }/media/thumbnail/${ mediaObj.title }`;
-                        // albumObj.cover_url = `https://res.cloudinary.com/${ process.env.CLOUDINARY_CLOUD_NAME }/image/upload/w_400,h_400,c_thumb/${ process.env.CLOUDINARY_SERVER_ACCESS_KEY }/${ mediaObj.user_id }/${ mediaObj.title }.jpg`;
-                        
-                      } else {
-                        
-                        albumObj.cover_url = `${ serverHost }/media/thumbnail/placeholder.jpg`;
-                        
-                      }
-                      
-                    });
-                    
-                  }
-                  
-                  delete albumObj.cover_id;
-                  
-                });
-                
-                if (isOwner || isAdmin) {
-                  
-                  // Send all albums.
-                  res.status(200).json(albumsArr);
-                  
-                } else {
-                  
-                  // Send public albums only.
-                  res.status(200).json(albumsArr.filter(albumObj => albumObj.access !== 'private'));
-                  
-                }
-                
-                
-              }  
-              
-            });
+            const withCovers = await genCoverPromiseArray(albumsArr);
 
+            if (isOwner || isAdmin) {
+              
+              // Send all albums.
+              res.status(200).json(withCovers);
+              
+            } else {
+              
+              // Send public albums only.
+              res.status(200).json(withCovers.filter(albumObj => albumObj.access !== 'private'));
+              
+            }
+      
           }
 
         });
@@ -287,10 +237,11 @@ const getAlbum = (req, res, next) => {
         
         else {
 
-          generateAlbumCover(albumObj, (mediaErr, albumWithCover) => {
+          generateCoverUpdated(albumObj, (mediaErr, albumWithCover) => {
 
             if (mediaErr) next(mediaErr);
             else res.status(200).json(albumWithCover);
+
           });
         }
 
@@ -341,7 +292,7 @@ const editAlbumMeta = (req, res, next) => {
 
         const responseHandler = (albumObj) => {
 
-          generateAlbumCover(albumObj, (mediaErr, albumWithCover) => {
+          generateCoverUpdated(albumObj, (mediaErr, albumWithCover) => {
 
             if (mediaErr) next(mediaErr);
             else res.status(200).json(albumWithCover);

--- a/api/controllers/collaborator.js
+++ b/api/controllers/collaborator.js
@@ -31,7 +31,30 @@ const getCollaborators = (req, res, next) => {
 
 const deleteCollaborator = (req, res, next) => {
 
+  const collaborator_id = parseInt(req.params.collaborator_id);
 
+  try {
+
+    if (req.isOwner || req.isAdmin) {
+
+      collaborator.removeCollaborator(collaborator_id, (collabErr, deleted) => {
+
+        if (collabErr) next(collabErr);
+        else if (!deleted) next(new Error(errors.serverError))
+        else {
+
+          res.status(200).json({ deleted_id: collaborator_id });
+
+        }
+
+      });
+
+    } else next(new Error(errors.unauthorized));
+
+  } catch(err) {
+    console.error(err);
+    next(err);
+  }
 
 };
 

--- a/api/controllers/collaborator.js
+++ b/api/controllers/collaborator.js
@@ -1,0 +1,41 @@
+const { collaborator } = require('../../data/models/models');
+const errors = require('../../modules/modules').errors;
+
+const getCollaborators = (req, res, next) => {
+
+  const album_id = parseInt(req.params.album_id);
+
+  try {
+
+    if (req.isOwner || req.isAdmin) {
+
+      collaborator.getCollaborators(album_id, (collabErr, collabArr) => {
+
+        if (collabErr) next(collabErr);
+        else {
+
+          res.status(200).json(collabArr);
+
+        }
+
+      });
+
+    } else next(new Error(errors.unauthorized));
+
+  } catch(err) {
+    console.error(err);
+    next(err);
+  }
+
+};
+
+const deleteCollaborator = (req, res, next) => {
+
+
+
+};
+
+module.exports = {
+  getCollaborators,
+  deleteCollaborator,
+};

--- a/api/controllers/controllers.js
+++ b/api/controllers/controllers.js
@@ -5,4 +5,5 @@ module.exports = {
   upload: require('./upload'),
   media:  require('./media'),
   invitation: require('./invitation'),
+  collaborator: require('./collaborator'),
 }

--- a/api/controllers/media.js
+++ b/api/controllers/media.js
@@ -141,7 +141,7 @@ const getAlbumsMedia = (req, res, next) => {
       if (retrieveErr) next(retrieveErr);
       else {
 
-        if (req.isAdmin || req.isOwner) {
+        if (req.isAdmin || req.isOwner || req.isCollab) {
 
           // Add image url to media.
           mediaArr.forEach((mediaObj, i) => {

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -73,6 +73,7 @@ const verifyPermission = (req, res, next) => {
       case routes.editAlbumMeta():
       case routes.createInvitation():
       case routes.getInvitesByAlbum():
+      case routes.getCollaborators():
         
         const album_id = parseInt(req.params.album_id);
 

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -74,6 +74,7 @@ const verifyPermission = (req, res, next) => {
       case routes.createInvitation():
       case routes.getInvitesByAlbum():
       case routes.getCollaborators():
+      case routes.deleteCollaborator():
         
         const album_id = parseInt(req.params.album_id);
 

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -183,7 +183,7 @@ const verifyPermission = (req, res, next) => {
                 else {
 
                   req.isOwner = userObj.user_id === inviteObj.invited_user_id;
-                  res.isAdmin = userObj.is_admin;
+                  req.isAdmin = userObj.is_admin;
                   next();
 
                 }

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -91,8 +91,6 @@ const verifyPermission = (req, res, next) => {
 
                   models.collaborator.checkCollaboration(album_id, userObj.user_id, (collabErr, isCollab) => {
 
-                    console.log('isCollab', isCollab);
-
                     if (collabErr) next(collabErr);
                     else {
 

--- a/api/routes/collaborator.js
+++ b/api/routes/collaborator.js
@@ -1,0 +1,54 @@
+const express     = require('express');
+const router      = express.Router();
+const errors      = require('../../modules/modules').errors;
+const routes      = require('../../modules/modules').routes;
+const controllers = require('../controllers/controllers');
+const middleware  = require('../middleware/middleware');
+const Sentry      = require('@sentry/node');
+const sentryError = Sentry.Handlers.errorHandler();
+const api         = { ...controllers, ...middleware };
+
+router.get(routes.getCollaborators(), api.auth.verifyToken, api.auth.verifyPermission, api.collaborator.getCollaborators);
+
+router.delete(routes.deleteCollaborator(), api.auth.verifyToken, api.collaborator.deleteCollaborator);
+
+// Error handler
+router.use((err, req, res, next) => {
+
+  switch (err.message) {
+    case errors.unauthorized:
+      res.status(401).json({ unauthorized: errors.unauthorized });
+      break;
+    case errors.collaboratorDoesNotExist:
+      res.status(404).json({ collaboratorDoesNotExist: errors.collaboratorDoesNotExist });
+      break;
+    case errors.tooManyProps:
+      res.status(400).json({ tooManyProps: errors.tooManyProps });
+      break;
+    case errors.noPropsFound:
+      res.status(400).json({ noPropsFound: errors.noPropsFound });
+      break;
+    case errors.invalidProps:
+      res.status(400).json({ invalidProps: errors.invalidProps });
+      break;
+    case errors.invalidAlbumDescription:
+      res.status(400).json({ invalidAlbumDescription: errors.invalidAlbumDescription });
+      break;
+    case errors.invalidAlbumAccess:
+      res.status(400).json({ invalidAlbumAccess: errors.invalidAlbumAccess });
+      break;
+    case errors.albumIdDoesNotExist:
+      res.status(404).json({ albumIdDoesNotExist: errors.albumIdDoesNotExist });
+      break;
+    case errors.serverError:
+      res.status(500).json({ serverError: errors.serverError });
+      break;
+    default:
+      console.error(err);
+      res.status(500).json({ serverError: errors.serverError });
+      break;
+  };
+
+});
+
+module.exports = router;

--- a/api/routes/collaborator.js
+++ b/api/routes/collaborator.js
@@ -8,8 +8,99 @@ const Sentry      = require('@sentry/node');
 const sentryError = Sentry.Handlers.errorHandler();
 const api         = { ...controllers, ...middleware };
 
+// GET HTTP/1.1 200 OK
+// #region
+/**
+ * 
+ *  @api {get} /albums/:album_id/collaborators Get all collaborators belonging to an album
+ *  @apiName Get-collaborators
+ *  @apiGroup Collaborators
+ *  @apiVersion 0.1.0
+ * 
+ *  @apiPermission owner
+ * 
+ *  @apiHeader (Headers) {String} [Authorization] JWT for user auth
+ * 
+ *  @apiHeaderExample {json} Header Example
+ *     {
+ *          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw"
+ *     }
+ * 
+ *  @apiParam (URL Parameters) {Integer} album_id The album ID
+ * 
+ *  @apiSuccess {Object[]} collaborators A list of the album's collaborators
+ * 
+ *  @apiSuccessExample {json} Example Response
+ *     HTTP/1.1 200 OK
+ *     [{
+ *        "collaborator_id": 8,
+ *        "user_id": 2,
+ *        "album_id": 1,
+ *        "permissions": "view",
+ *        "expires_on": null,
+ *        "created_at": "2020-01-08 13:45:02",
+ *        "display_name": "test2",
+ *        "email": "test2@test.com"
+ *      }]
+ * 
+ *   @apiError {Object} albumIdDoesNotExist The album_id does not exist in the database
+ *   @apiError {Object} collaboratorDoesNotExist The collaborator_id does not exist in the database
+ *   @apiError {Object} invalidAlbumAccess You lack sufficient permissions with that album to perform that action
+ *   @apiError {Object} unauthorized Not logged in, or not authorized to interact with that album
+ *   @apiError {Object} serverError Internal server error
+ * 
+ *   @apiErrorExample Album Does Not Exist
+ *      HTTP/1.1 404
+ *      {
+ *          "albumIdDoesNotExist": "album_id does not exist"
+ *      }
+ * 
+ */
+// #endregion
 router.get(routes.getCollaborators(), api.auth.verifyToken, api.auth.verifyPermission, api.collaborator.getCollaborators);
 
+// DELETE HTTP/1.1 200 OK
+// #region
+/**
+ * 
+ *  @api {delete} /albums/:album_id/collaborators/:collaborator_id/remove Remove this collaborator's association with the album
+ *  @apiName Remove-collaborator
+ *  @apiGroup Collaborators
+ *  @apiVersion 0.1.0
+ * 
+ *  @apiPermission owner
+ * 
+ *  @apiHeader (Headers) {String} [Authorization] JWT for user auth
+ * 
+ *  @apiHeaderExample {json} Header Example
+ *     {
+ *          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw"
+ *     }
+ * 
+ *  @apiParam (URL Parameters) {Integer} album_id The album ID
+ * 
+ *  @apiSuccess {Integer} deleted The collaborator_id of the removed collaborator
+ * 
+ *  @apiSuccessExample {json} Example Response
+ *     HTTP/1.1 200 OK
+ *     {
+ *       "deleted": 6
+ *     }
+ * 
+ *   @apiError {Object} albumIdDoesNotExist The album_id does not exist in the database
+ *   @apiError {Object} collaboratorDoesNotExist The collaborator_id does not exist in the database
+ *   @apiError {Object} invalidAlbumAccess You lack sufficient permissions with that album to perform that action
+ *   @apiError {Object} unauthorized Not logged in, or not authorized to interact with that album
+ *   @apiError {Object} serverError Internal server error
+ * 
+ *   @apiErrorExample Album Does Not Exist
+ *      HTTP/1.1 404
+ *      {
+ *          "albumIdDoesNotExist": "album_id does not exist"
+ *      }
+ * 
+ */
+// #endregion
 router.delete(routes.deleteCollaborator(), api.auth.verifyToken, api.auth.verifyPermission, api.collaborator.deleteCollaborator);
 
 // Error handler
@@ -21,18 +112,6 @@ router.use((err, req, res, next) => {
       break;
     case errors.collaboratorDoesNotExist:
       res.status(404).json({ collaboratorDoesNotExist: errors.collaboratorDoesNotExist });
-      break;
-    case errors.tooManyProps:
-      res.status(400).json({ tooManyProps: errors.tooManyProps });
-      break;
-    case errors.noPropsFound:
-      res.status(400).json({ noPropsFound: errors.noPropsFound });
-      break;
-    case errors.invalidProps:
-      res.status(400).json({ invalidProps: errors.invalidProps });
-      break;
-    case errors.invalidAlbumDescription:
-      res.status(400).json({ invalidAlbumDescription: errors.invalidAlbumDescription });
       break;
     case errors.invalidAlbumAccess:
       res.status(400).json({ invalidAlbumAccess: errors.invalidAlbumAccess });

--- a/api/routes/collaborator.js
+++ b/api/routes/collaborator.js
@@ -10,7 +10,7 @@ const api         = { ...controllers, ...middleware };
 
 router.get(routes.getCollaborators(), api.auth.verifyToken, api.auth.verifyPermission, api.collaborator.getCollaborators);
 
-router.delete(routes.deleteCollaborator(), api.auth.verifyToken, api.collaborator.deleteCollaborator);
+router.delete(routes.deleteCollaborator(), api.auth.verifyToken, api.auth.verifyPermission, api.collaborator.deleteCollaborator);
 
 // Error handler
 router.use((err, req, res, next) => {

--- a/api/routes/invitation.js
+++ b/api/routes/invitation.js
@@ -27,13 +27,13 @@ const api         = { ...controllers, ...middleware };
  * 
  *  @apiParam (URL Parameters) {Integer} album_id The album ID
  *  @apiParam (Request Body) {Integer} user_id the user making the request
- *  @apiparam (Request Body) {Integer} invited_user_id the user to be invited
+ *  @apiparam (Request Body) {String} invited_email the email of user to be invited
  *  
  *  @apiParamExample {json} Example Request
  *      /albums/4563/invites/create
  *      {
  *          "user_id": 45,
- *          "invited_user_id": 132
+ *          "invited_email": "test@gmail.com"
  *      }
  * 
  *  @apiSuccess {Object[]} invitation the invitation object

--- a/api/routes/routes.js
+++ b/api/routes/routes.js
@@ -7,6 +7,7 @@ router.use([
   require('./album'),
   require('./media'),
   require('./invitation'),
+  require('./collaborator'),
 ]);
 
 module.exports = router;

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1227,6 +1227,238 @@ define({ "api": [
     "groupTitle": "Albums"
   },
   {
+    "type": "get",
+    "url": "/albums/:album_id/collaborators",
+    "title": "Get all collaborators belonging to an album",
+    "name": "Get_collaborators",
+    "group": "Collaborators",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "owner"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": true,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Object[]",
+            "optional": false,
+            "field": "collaborators",
+            "description": "<p>A list of the album's collaborators</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n[{\n   \"collaborator_id\": 8,\n   \"user_id\": 2,\n   \"album_id\": 1,\n   \"permissions\": \"view\",\n   \"expires_on\": null,\n   \"created_at\": \"2020-01-08 13:45:02\",\n   \"display_name\": \"test2\",\n   \"email\": \"test2@test.com\"\n }]",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "albumIdDoesNotExist",
+            "description": "<p>The album_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "collaboratorDoesNotExist",
+            "description": "<p>The collaborator_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "invalidAlbumAccess",
+            "description": "<p>You lack sufficient permissions with that album to perform that action</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>Not logged in, or not authorized to interact with that album</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Album Does Not Exist",
+          "content": "HTTP/1.1 404\n{\n    \"albumIdDoesNotExist\": \"album_id does not exist\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/collaborator.js",
+    "groupTitle": "Collaborators"
+  },
+  {
+    "type": "delete",
+    "url": "/albums/:album_id/collaborators/:collaborator_id/remove",
+    "title": "Remove this collaborator's association with the album",
+    "name": "Remove_collaborator",
+    "group": "Collaborators",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "owner"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": true,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "deleted",
+            "description": "<p>The collaborator_id of the removed collaborator</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n{\n  \"deleted\": 6\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "albumIdDoesNotExist",
+            "description": "<p>The album_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "collaboratorDoesNotExist",
+            "description": "<p>The collaborator_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "invalidAlbumAccess",
+            "description": "<p>You lack sufficient permissions with that album to perform that action</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>Not logged in, or not authorized to interact with that album</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Album Does Not Exist",
+          "content": "HTTP/1.1 404\n{\n    \"albumIdDoesNotExist\": \"album_id does not exist\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/collaborator.js",
+    "groupTitle": "Collaborators"
+  },
+  {
     "type": "post",
     "url": "/albums/:album_id/invites/create",
     "title": "Invite a user to collaborate on an album",

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1279,17 +1279,17 @@ define({ "api": [
           },
           {
             "group": "Request Body",
-            "type": "Integer",
+            "type": "String",
             "optional": false,
-            "field": "invited_user_id",
-            "description": "<p>the user to be invited</p>"
+            "field": "invited_email",
+            "description": "<p>the email of user to be invited</p>"
           }
         ]
       },
       "examples": [
         {
           "title": "Example Request",
-          "content": "/albums/4563/invites/create\n{\n    \"user_id\": 45,\n    \"invited_user_id\": 132\n}",
+          "content": "/albums/4563/invites/create\n{\n    \"user_id\": 45,\n    \"invited_email\": \"test@gmail.com\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1279,17 +1279,17 @@
           },
           {
             "group": "Request Body",
-            "type": "Integer",
+            "type": "String",
             "optional": false,
-            "field": "invited_user_id",
-            "description": "<p>the user to be invited</p>"
+            "field": "invited_email",
+            "description": "<p>the email of user to be invited</p>"
           }
         ]
       },
       "examples": [
         {
           "title": "Example Request",
-          "content": "/albums/4563/invites/create\n{\n    \"user_id\": 45,\n    \"invited_user_id\": 132\n}",
+          "content": "/albums/4563/invites/create\n{\n    \"user_id\": 45,\n    \"invited_email\": \"test@gmail.com\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1227,6 +1227,238 @@
     "groupTitle": "Albums"
   },
   {
+    "type": "get",
+    "url": "/albums/:album_id/collaborators",
+    "title": "Get all collaborators belonging to an album",
+    "name": "Get_collaborators",
+    "group": "Collaborators",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "owner"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": true,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Object[]",
+            "optional": false,
+            "field": "collaborators",
+            "description": "<p>A list of the album's collaborators</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n[{\n   \"collaborator_id\": 8,\n   \"user_id\": 2,\n   \"album_id\": 1,\n   \"permissions\": \"view\",\n   \"expires_on\": null,\n   \"created_at\": \"2020-01-08 13:45:02\",\n   \"display_name\": \"test2\",\n   \"email\": \"test2@test.com\"\n }]",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "albumIdDoesNotExist",
+            "description": "<p>The album_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "collaboratorDoesNotExist",
+            "description": "<p>The collaborator_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "invalidAlbumAccess",
+            "description": "<p>You lack sufficient permissions with that album to perform that action</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>Not logged in, or not authorized to interact with that album</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Album Does Not Exist",
+          "content": "HTTP/1.1 404\n{\n    \"albumIdDoesNotExist\": \"album_id does not exist\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/collaborator.js",
+    "groupTitle": "Collaborators"
+  },
+  {
+    "type": "delete",
+    "url": "/albums/:album_id/collaborators/:collaborator_id/remove",
+    "title": "Remove this collaborator's association with the album",
+    "name": "Remove_collaborator",
+    "group": "Collaborators",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "owner"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": true,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "deleted",
+            "description": "<p>The collaborator_id of the removed collaborator</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n{\n  \"deleted\": 6\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "albumIdDoesNotExist",
+            "description": "<p>The album_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "collaboratorDoesNotExist",
+            "description": "<p>The collaborator_id does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "invalidAlbumAccess",
+            "description": "<p>You lack sufficient permissions with that album to perform that action</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>Not logged in, or not authorized to interact with that album</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Album Does Not Exist",
+          "content": "HTTP/1.1 404\n{\n    \"albumIdDoesNotExist\": \"album_id does not exist\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/collaborator.js",
+    "groupTitle": "Collaborators"
+  },
+  {
     "type": "post",
     "url": "/albums/:album_id/invites/create",
     "title": "Invite a user to collaborate on an album",

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-08T03:07:03.659Z",
+    "time": "2020-01-08T13:53:36.263Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2019-12-29T09:17:40.806Z",
+    "time": "2020-01-08T03:07:03.659Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2019-12-29T09:17:40.806Z",
+    "time": "2020-01-08T03:07:03.659Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-08T03:07:03.659Z",
+    "time": "2020-01-08T13:53:36.263Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/data/models/album.js
+++ b/data/models/album.js
@@ -258,11 +258,13 @@ const updateAlbumById = (album_id, albumObj, done) => {
 
           // Get users albums titles.
           db('albums').where({ user_id })
-            .select('title').then(titleArr => {
+            .select('title', 'album_id').then(titleArr => {
 
               // Check if user already has an album with the title.
               let titleExists = false;
-              titleArr.forEach(titleObj => (titleObj.title.toLowerCase() === title.toLowerCase()) && (titleExists = true));
+              titleArr.forEach(titleObj => {
+                if (titleObj.title.toLowerCase() === title.toLowerCase() && titleObj.album_id != album_id) titleExists = true;
+              });
 
               if (titleExists) done(new Error(errors.albumTitleExists));
               else {

--- a/data/models/collaborator.js
+++ b/data/models/collaborator.js
@@ -3,7 +3,7 @@ const errors   = require('../../modules/modules').errors;
 
 const retrieveCollabAlbums = (user_id, done) => {
 
-  db('collaborators').where({ user_id })
+  db('collaborators').where('collaborators.user_id', user_id)
     .join('albums', 'collaborators.album_id', 'albums.album_id')
     .then(albums => {
 
@@ -11,7 +11,7 @@ const retrieveCollabAlbums = (user_id, done) => {
       done(null, albums);
 
     }).catch(err => {
-      console.error(err);
+      console.error('retrieveCollabAlbums', err);
       done(err);
     });
 

--- a/data/models/collaborator.js
+++ b/data/models/collaborator.js
@@ -7,13 +7,9 @@ const retrieveCollabAlbums = (user_id, done) => {
     .join('albums', 'collaborators.album_id', 'albums.album_id')
     .then(albums => {
 
-      console.log(albums);
       done(null, albums);
 
-    }).catch(err => {
-      console.error('retrieveCollabAlbums', err);
-      done(err);
-    });
+    }).catch(err => done(err));
 
 };
 

--- a/data/models/collaborator.js
+++ b/data/models/collaborator.js
@@ -25,7 +25,44 @@ const checkCollaboration = (album_id, user_id, done) => {
 
 };
 
+const removeCollaborator = (collaborator_id, done) => {
+
+  db('collaborators').where({ collaborator_id })
+    .del()
+    .then(deleted => {
+
+      if (deleted) done(null, deleted);
+      else done(new Error(errors.collaboratorDoesNotExist))
+
+    }).catch(err => done(err));
+
+};
+
+const getCollaborators = (album_id, done) => {
+
+  db('collaborators').where('collaborators.album_id', album_id)
+    .join('users', 'collaborators.user_id', 'users.user_id')
+    .select(
+      'collaborator_id',
+      'collaborators.user_id',
+      'album_id',
+      'permissions',
+      'expires_on',
+      'collaborators.created_at',
+      'display_name',
+      'email',
+    )
+    .then(collabs => {
+    
+      done(null, collabs);
+
+    }).catch(err => done(err));
+
+};
+
 module.exports = {
   retrieveCollabAlbums,
   checkCollaboration,
+  removeCollaborator,
+  getCollaborators,
 };

--- a/modules/errors.js
+++ b/modules/errors.js
@@ -54,5 +54,6 @@ module.exports = {
   invitationAlreadyexists: 'an invitation already exists',
   invitationDoesNotExist:  'invite id does not exist',
   alreadyCollaborator:     'user is already a collaborator',
+  collaboratorDoesNotExist: 'that collaborator does not exist'
 
 };

--- a/modules/routes.js
+++ b/modules/routes.js
@@ -41,7 +41,7 @@ module.exports = {
   acceptInvitation: (invite_id) => (typeof invite_id !== 'undefined' ? `/invites/${ invite_id }/accept` : '/invites/:invite_id/accept'),
 
   // Collaborators
-  deleteCollaborator: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/collaborators/remove`: '/albums/:album_id/collaborators/remove'),
+  deleteCollaborator: (album_id, collaborator_id) => (typeof album_id !== 'undefined' && typeof collaborator_id !== 'undefined' ? `/albums/${ album_id }/collaborators/${ collaborator_id }/remove`: '/albums/:album_id/collaborators/:collaborator_id/remove'),
   getCollaborators: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/collaborators`: '/albums/:album_id/collaborators'),
 
 };

--- a/modules/routes.js
+++ b/modules/routes.js
@@ -40,4 +40,8 @@ module.exports = {
   removeInvitation: (invite_id) => (typeof invite_id !== 'undefined' ? `/invites/${ invite_id }/remove` : '/invites/:invite_id/remove'),
   acceptInvitation: (invite_id) => (typeof invite_id !== 'undefined' ? `/invites/${ invite_id }/accept` : '/invites/:invite_id/accept'),
 
+  // Collaborators
+  deleteCollaborator: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/collaborators/remove`: '/albums/:album_id/collaborators/remove'),
+  getCollaborators: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/collaborators`: '/albums/:album_id/collaborators'),
+
 };

--- a/test/controllers/album.js
+++ b/test/controllers/album.js
@@ -832,7 +832,7 @@ describe('Album endpoint tests', () => {
     it('should respond with a 400 status code when the title already exists', done => {
 
       const { email, password } = Object.assign({}, USERS[0], { password: PASS });
-      const { album_id } = ALBUMS[0];
+      const { album_id } = ALBUMS[1];
       const album = {
         title: 'A title'
       }
@@ -870,7 +870,7 @@ describe('Album endpoint tests', () => {
     it('should respond with an albumTitleExists property when the title already exists', done => {
 
       const { email, password } = Object.assign({}, USERS[0], { password: PASS });
-      const { album_id } = ALBUMS[0];
+      const { album_id } = ALBUMS[1];
       const album = {
         title: 'A title'
       }

--- a/test/models/album.js
+++ b/test/models/album.js
@@ -334,7 +334,7 @@ describe('Testing album models', () => {
 
     it('should pass an error to a callback function when the title already exists', done => {
 
-      const { album_id } = ALBUMS[0];
+      const { album_id } = ALBUMS[1];
       albumData = {
         title: 'A Title',
         description: 'New Description',


### PR DESCRIPTION
# Description

Further built out and cleaned up the invitation and collaboration system

You can now retrieve a list of collaborators on a given album as well as delete collaborators from it.

I went through each route and did my best to ensure that they'd be compatible with collaborators. In most cases, only very small changes were made. If I missed something, please let me know, and I'll jump on it asap.

I rewrote the code to retrieve/generate cover_urls for albums. It should not affect existing usage but will make it compatible with collaboration, and hopefully easier to maintain.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
