### PR TITLE
Media edit and delete

### DIFF
--- a/api/controllers/invitation.js
+++ b/api/controllers/invitation.js
@@ -1,5 +1,6 @@
 const { invitation, collaborator, user }      = require('../../data/models/models');
 const errors      = require('../../modules/modules').errors;
+const { genCoverPromiseArray } = require('../../modules/coverAlbum');
 
 const createInvitation = (req, res, next) => {
 
@@ -100,10 +101,15 @@ const getInvitesForUser = (req, res, next) => {
 
     try {
       
-      invitation.getInvitesForUser(user_id, (inviteErr, inviteArr) => {
+      invitation.getInvitesForUser(user_id, async (inviteErr, inviteArr) => {
 
         if (inviteErr) next(inviteErr);
-        else res.status(200).json(inviteArr);
+        else {
+
+          const invitesWithCovers = await genCoverPromiseArray(inviteArr);
+          res.status(200).json(invitesWithCovers);
+
+        }
 
       });
 

--- a/api/controllers/media.js
+++ b/api/controllers/media.js
@@ -289,10 +289,46 @@ const viewMedia = (req, res, next) => {
 
 };
 
+const editMedia = (req, res, next) => {
+
+  const { media_id } = req.params;
+
+  if (req.isOwner || req.isAdmin || req.isCollab) {
+
+
+
+  } else next(new Error(errors.unauthorized));
+
+};
+
+const deleteMedia = (req, res, next) => {
+
+  const { album_id } = req.params;
+  const { media_id } = req.params;
+
+  if (req.isOwner || req.isAdmin || req.isCollab) {
+
+    models.media.deleteAlbumMedia(album_id, media_id, (err) => {
+      
+      if(err) next(err);
+      else {
+
+        res.status(204).end();
+
+      }
+
+    });
+
+  } else next(new Error(errors.unauthorized));
+
+};
+
 module.exports = {
   addAlbumsMedia,
   getAlbumsMedia,
   getUsersMedia,
   viewUsersMedia,
   viewMedia,
+  editMedia,
+  deleteMedia,
 };

--- a/api/controllers/media.js
+++ b/api/controllers/media.js
@@ -300,7 +300,7 @@ const editMedia = (req, res, next) => {
       if (editErr) next(editErr);
       else {
 
-        res.status(200).json(edited);
+        res.status(200).json({ edited: media_id });
 
       }
 

--- a/api/controllers/media.js
+++ b/api/controllers/media.js
@@ -292,10 +292,19 @@ const viewMedia = (req, res, next) => {
 const editMedia = (req, res, next) => {
 
   const { media_id } = req.params;
-
+  
   if (req.isOwner || req.isAdmin || req.isCollab) {
 
+    models.media.editMedia(media_id, req.body, (editErr, edited) => {
 
+      if (editErr) next(editErr);
+      else {
+
+        res.status(200).json(edited);
+
+      }
+
+    });
 
   } else next(new Error(errors.unauthorized));
 

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -74,6 +74,8 @@ const verifyPermission = (req, res, next) => {
       case routes.createInvitation():
       case routes.getInvitesByAlbum():
       case routes.getCollaborators():
+      case routes.deleteMedia():
+      case routes.editMedia():
         
         const album_id = parseInt(req.params.album_id);
 
@@ -219,7 +221,7 @@ const verifyPermission = (req, res, next) => {
 
                     if (collabErr) next(collabErr);
                     else {
-                      
+
                       req.isOwner = userObj.user_id === albumObj.user_id || userObj.user_id === collabObj.user_id;
                       req.isAdmin = userObj.is_admin;
                       next();

--- a/api/routes/invitation.js
+++ b/api/routes/invitation.js
@@ -208,7 +208,10 @@ router.get(routes.getInvitesByUser(), api.auth.verifyToken, api.auth.verifyPermi
  *        "invited_user_id": 2343,
  *        "created_at": "2019-11-06 18:42:57",
  *        "user_email": "test2@test.com",
- *        "user_name": "test2"
+ *        "user_name": "test2",
+ *        "title": "a title",
+ *        "description": "a description",
+ *        "cover_url": "htts://photos.com/yourphoto"
  *     }, {
  *        "invitation_id": 2345
  *        "album_id": 4356,
@@ -216,7 +219,10 @@ router.get(routes.getInvitesByUser(), api.auth.verifyToken, api.auth.verifyPermi
  *        "invited_user_id": 2343,
  *        "created_at": "2019-11-06 18:42:57",
  *        "user_email": "test3@test.com",
- *        "user_name": "test3"
+ *        "user_name": "test3",
+ *        "title": "a title",
+ *        "description": "a description",
+ *        "cover_url": "htts://photos.com/yourphoto"
  *     }]
  *  
  *   @apiError {Object} missingUserId the user_id was missing or not parsed correctly

--- a/api/routes/media.js
+++ b/api/routes/media.js
@@ -280,6 +280,119 @@ router.get(routes.getAlbumsMedia(), api.auth.verifyToken, api.auth.verifyPermiss
 // #endregion
 router.get(routes.getUsersMedia(), api.auth.verifyToken, api.auth.verifyPermission, api.media.getUsersMedia, sentryError);
 
+// HTTP/1.1 200 OK
+// #region
+/**
+ * 
+ *  @api {put} /albums/:album_id/media/:media_id/edit Get a users media
+ *  @apiName edit-media
+ *  @apiGroup Media
+ *  @apiVersion 0.1.0
+ * 
+ *  @apiPermission admin owner collaborator
+ * 
+ *  @apiHeader (Headers) {String} Authorization JWT for user auth
+ * 
+ *  @apiHeaderExample {json} Header Example
+ *     {
+ *          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw"
+ *     }
+ * 
+ *  @apiParam (URL Parameters) {Integer} media_id The media ID
+ *  @apiParam (URL Parameters) {Integer} album_id The album ID
+ * 
+ *  @apiParam (Request Body) {String} title A new title for the media
+ *  @apiparam (Request Body) {String} caption A new caption for the media
+ *  @apiParam (Request Body) {String[]} [keywords] A new list of keywords describing the media
+ *  @apiParam (Request Body) {Object[]} [meta] A new list of meta data objects
+ *  @apiParam (Request Body) {String} meta[name] The name of the meta field
+ *  @apiParam (Request Body) {String} meta[value] The value of the meta field
+ * 
+ *  @apiParamExample {json} Example Request
+ *      /users/6542/media/add
+ *      {
+ *        "title": "A Photo Title",
+ *        "caption": "A short caption for a photo",
+ *        "keywords": ["keyword-one", "keyword-two", "keyword-three"],
+ *        "meta": [{
+ *          "name": "Location",
+ *          "value": "Mexico"
+ *        }]
+ *      }
+ * 
+ *  @apiSuccessExample {json} Example Response
+ *     HTTP/1.1 200 OK
+ *     {
+ *       "edited_id": 34532
+ *     }
+ * 
+ *   @apiError {Object} userIdDoesNotExist The album ID does not exist in the database
+ *   @apiError {Object} unauthorized You are not authorized to make the request
+ *   @apiError {Object} serverError Internal server error
+ * 
+ *   @apiErrorExample Does Not Exists
+ *      HTTP/1.1 404
+ *      {
+ *          "userIdDoesNotExist": "album id does not exist"
+ *      }
+ * 
+ *   @apiErrorExample Server Error
+ *      HTTP/1.1 500
+ *      {
+ *          "serverError": "server error"
+ *      }
+ * 
+ */
+// #endregion
+router.put(routes.editMedia(), api.auth.verifyToken, api.auth.verifyPermission, api.media.editMedia, sentryError);
+
+// HTTP/1.1 204 NO CONTENT
+// #region
+/**
+ * 
+ *  @api {delete} /albums/:album_id/media/:media_id/remove Remove a piece of media from an album
+ *  @apiName remove-media
+ *  @apiGroup Media
+ *  @apiVersion 0.1.0
+ * 
+ *  @apiPermission admin owner collaborator
+ * 
+ *  @apiHeader (Headers) {String} Authorization JWT for user auth
+ * 
+ *  @apiHeaderExample {json} Header Example
+ *     {
+ *          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw"
+ *     }
+ * 
+ *  @apiParam (URL Parameters) {Integer} album_id The album ID
+ *  @apiParam (URL Parameters) {Integer} media_id The media ID
+ * 
+ *  @apiParamExample {json} Example Request
+ *      /albums/6542/media/23545/remove
+ * 
+ *  @apiSuccessExample {json} Example Response
+ *     HTTP/1.1 204 NO CONTENT
+ * 
+ *   @apiError {Object} userIdDoesNotExist The album ID does not exist in the database
+ *   @apiError {Object} unauthorized You are not authorized to make the request
+ *   @apiError {Object} serverError Internal server error
+ * 
+ *   @apiErrorExample Does Not Exists
+ *      HTTP/1.1 404
+ *      {
+ *          "userIdDoesNotExist": "album id does not exist"
+ *      }
+ * 
+ *   @apiErrorExample Server Error
+ *      HTTP/1.1 500
+ *      {
+ *          "serverError": "server error"
+ *      }
+ * 
+ */
+// #endregion
+router.delete(routes.deleteMedia(), api.auth.verifyToken, api.auth.verifyPermission, api.media.deleteMedia, sentryError);
+
 // Route for serving users media from Cloudinary.
 router.get(routes.viewUsersMedia(), /* api.auth.verifyToken, api.auth.verifyPermission, */ api.media.viewUsersMedia, sentryError);
 
@@ -344,6 +457,9 @@ router.use((err, req, res, next) => {
     case errors.unauthorized:
       res.status(401).json({ unauthorized: errors.unauthorized });
         break;
+    case errors.mediaAlbumDoesNotExist:
+      res.status(404).json({ mediaAlbumDoesNotExist: errors.mediaAlbumDoesNotExist });
+      break;
     case errors.serverError:
       res.status(500).json({ serverError: errors.serverError });
         break;

--- a/api/routes/media.js
+++ b/api/routes/media.js
@@ -301,7 +301,7 @@ router.get(routes.getUsersMedia(), api.auth.verifyToken, api.auth.verifyPermissi
  *  @apiParam (URL Parameters) {Integer} media_id The media ID
  *  @apiParam (URL Parameters) {Integer} album_id The album ID
  * 
- *  @apiParam (Request Body) {String} title A new title for the media
+ *  @apiParam (Request Body) {String} title A new title for the media CURRENTLY DISABLED. WILL REQUIRE REDESIGN OF MEDIA SCHEMA TO WORK PROPERLY
  *  @apiparam (Request Body) {String} caption A new caption for the media
  *  @apiParam (Request Body) {String[]} [keywords] A new list of keywords describing the media. keywords undefined or falsy indicates no changes
  *  @apiParam (Request Body) {Object[]} [meta] A new list of meta data objects. meta undefined or falsy indicates no changes

--- a/api/routes/media.js
+++ b/api/routes/media.js
@@ -284,7 +284,7 @@ router.get(routes.getUsersMedia(), api.auth.verifyToken, api.auth.verifyPermissi
 // #region
 /**
  * 
- *  @api {put} /albums/:album_id/media/:media_id/edit Get a users media
+ *  @api {put} /albums/:album_id/media/:media_id/edit Update a piece of media
  *  @apiName edit-media
  *  @apiGroup Media
  *  @apiVersion 0.1.0

--- a/api/routes/media.js
+++ b/api/routes/media.js
@@ -303,13 +303,13 @@ router.get(routes.getUsersMedia(), api.auth.verifyToken, api.auth.verifyPermissi
  * 
  *  @apiParam (Request Body) {String} title A new title for the media
  *  @apiparam (Request Body) {String} caption A new caption for the media
- *  @apiParam (Request Body) {String[]} [keywords] A new list of keywords describing the media
- *  @apiParam (Request Body) {Object[]} [meta] A new list of meta data objects
+ *  @apiParam (Request Body) {String[]} [keywords] A new list of keywords describing the media. keywords undefined or falsy indicates no changes
+ *  @apiParam (Request Body) {Object[]} [meta] A new list of meta data objects. meta undefined or falsy indicates no changes
  *  @apiParam (Request Body) {String} meta[name] The name of the meta field
  *  @apiParam (Request Body) {String} meta[value] The value of the meta field
  * 
  *  @apiParamExample {json} Example Request
- *      /users/6542/media/add
+ *      /albums/6542/media/3535/edit
  *      {
  *        "title": "A Photo Title",
  *        "caption": "A short caption for a photo",

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -1984,7 +1984,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Example Response",
-          "content": "HTTP/1.1 200 OK\n[{  \n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test2@test.com\",\n   \"user_name\": \"test2\"\n}, {\n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test3@test.com\",\n   \"user_name\": \"test3\"\n}]",
+          "content": "HTTP/1.1 200 OK\n[{  \n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test2@test.com\",\n   \"user_name\": \"test2\",\n   \"title\": \"a title\",\n   \"description\": \"a description\",\n   \"cover_url\": \"htts://photos.com/yourphoto\"\n}, {\n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test3@test.com\",\n   \"user_name\": \"test3\",\n   \"title\": \"a title\",\n   \"description\": \"a description\",\n   \"cover_url\": \"htts://photos.com/yourphoto\"\n}]",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -2669,7 +2669,7 @@ define({ "api": [
             "type": "String",
             "optional": false,
             "field": "title",
-            "description": "<p>A new title for the media</p>"
+            "description": "<p>A new title for the media CURRENTLY DISABLED. WILL REQUIRE REDESIGN OF MEDIA SCHEMA TO WORK PROPERLY</p>"
           },
           {
             "group": "Request Body",

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -2616,7 +2616,7 @@ define({ "api": [
   {
     "type": "put",
     "url": "/albums/:album_id/media/:media_id/edit",
-    "title": "Get a users media",
+    "title": "Update a piece of media",
     "name": "edit_media",
     "group": "Media",
     "version": "0.1.0",

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -2615,6 +2615,270 @@ define({ "api": [
   },
   {
     "type": "put",
+    "url": "/albums/:album_id/media/:media_id/edit",
+    "title": "Get a users media",
+    "name": "edit_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          },
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ],
+        "Request Body": [
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "title",
+            "description": "<p>A new title for the media</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "caption",
+            "description": "<p>A new caption for the media</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String[]",
+            "optional": true,
+            "field": "keywords",
+            "description": "<p>A new list of keywords describing the media. keywords undefined or falsy indicates no changes</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "Object[]",
+            "optional": true,
+            "field": "meta",
+            "description": "<p>A new list of meta data objects. meta undefined or falsy indicates no changes</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "meta[name]",
+            "description": "<p>The name of the meta field</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "meta[value]",
+            "description": "<p>The value of the meta field</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/albums/6542/media/3535/edit\n{\n  \"title\": \"A Photo Title\",\n  \"caption\": \"A short caption for a photo\",\n  \"keywords\": [\"keyword-one\", \"keyword-two\", \"keyword-three\"],\n  \"meta\": [{\n    \"name\": \"Location\",\n    \"value\": \"Mexico\"\n  }]\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n{\n  \"edited_id\": 34532\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "delete",
+    "url": "/albums/:album_id/media/:media_id/remove",
+    "title": "Remove a piece of media from an album",
+    "name": "remove_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          },
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/albums/6542/media/23545/remove",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 204 NO CONTENT",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "put",
     "url": "/users/{user_id}/edit",
     "title": "Edit a user",
     "name": "Edit_user",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -2615,6 +2615,270 @@
   },
   {
     "type": "put",
+    "url": "/albums/:album_id/media/:media_id/edit",
+    "title": "Get a users media",
+    "name": "edit_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          },
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          }
+        ],
+        "Request Body": [
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "title",
+            "description": "<p>A new title for the media</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "caption",
+            "description": "<p>A new caption for the media</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String[]",
+            "optional": true,
+            "field": "keywords",
+            "description": "<p>A new list of keywords describing the media. keywords undefined or falsy indicates no changes</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "Object[]",
+            "optional": true,
+            "field": "meta",
+            "description": "<p>A new list of meta data objects. meta undefined or falsy indicates no changes</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "meta[name]",
+            "description": "<p>The name of the meta field</p>"
+          },
+          {
+            "group": "Request Body",
+            "type": "String",
+            "optional": false,
+            "field": "meta[value]",
+            "description": "<p>The value of the meta field</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/albums/6542/media/3535/edit\n{\n  \"title\": \"A Photo Title\",\n  \"caption\": \"A short caption for a photo\",\n  \"keywords\": [\"keyword-one\", \"keyword-two\", \"keyword-three\"],\n  \"meta\": [{\n    \"name\": \"Location\",\n    \"value\": \"Mexico\"\n  }]\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 200 OK\n{\n  \"edited_id\": 34532\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "delete",
+    "url": "/albums/:album_id/media/:media_id/remove",
+    "title": "Remove a piece of media from an album",
+    "name": "remove_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "album_id",
+            "description": "<p>The album ID</p>"
+          },
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/albums/6542/media/23545/remove",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "HTTP/1.1 204 NO CONTENT",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "put",
     "url": "/users/{user_id}/edit",
     "title": "Edit a user",
     "name": "Edit_user",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -2616,7 +2616,7 @@
   {
     "type": "put",
     "url": "/albums/:album_id/media/:media_id/edit",
-    "title": "Get a users media",
+    "title": "Update a piece of media",
     "name": "edit_media",
     "group": "Media",
     "version": "0.1.0",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -2669,7 +2669,7 @@
             "type": "String",
             "optional": false,
             "field": "title",
-            "description": "<p>A new title for the media</p>"
+            "description": "<p>A new title for the media CURRENTLY DISABLED. WILL REQUIRE REDESIGN OF MEDIA SCHEMA TO WORK PROPERLY</p>"
           },
           {
             "group": "Request Body",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -1984,7 +1984,7 @@
       "examples": [
         {
           "title": "Example Response",
-          "content": "HTTP/1.1 200 OK\n[{  \n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test2@test.com\",\n   \"user_name\": \"test2\"\n}, {\n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test3@test.com\",\n   \"user_name\": \"test3\"\n}]",
+          "content": "HTTP/1.1 200 OK\n[{  \n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test2@test.com\",\n   \"user_name\": \"test2\",\n   \"title\": \"a title\",\n   \"description\": \"a description\",\n   \"cover_url\": \"htts://photos.com/yourphoto\"\n}, {\n   \"invitation_id\": 2345\n   \"album_id\": 4356,\n   \"user_id\": 6534,\n   \"invited_user_id\": 2343,\n   \"created_at\": \"2019-11-06 18:42:57\",\n   \"user_email\": \"test3@test.com\",\n   \"user_name\": \"test3\",\n   \"title\": \"a title\",\n   \"description\": \"a description\",\n   \"cover_url\": \"htts://photos.com/yourphoto\"\n}]",
           "type": "json"
         }
       ]

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-11T02:26:58.140Z",
+    "time": "2020-01-12T03:27:28.680Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T03:40:05.192Z",
+    "time": "2020-01-12T05:13:48.522Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T03:27:28.680Z",
+    "time": "2020-01-12T03:40:05.192Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T05:13:48.522Z",
+    "time": "2020-01-12T10:54:37.118Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T03:27:28.680Z",
+    "time": "2020-01-12T03:40:05.192Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-11T02:26:58.140Z",
+    "time": "2020-01-12T03:27:28.680Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T05:13:48.522Z",
+    "time": "2020-01-12T10:54:37.118Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T03:40:05.192Z",
+    "time": "2020-01-12T05:13:48.522Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/data/models/invitation.js
+++ b/data/models/invitation.js
@@ -122,14 +122,18 @@ const getInvitesForUser = (invited_user_id, done) => {
 
   db('invitations').where({ invited_user_id })
     .join('users', 'invitations.user_id', '=', 'users.user_id')
+    .join('albums', 'invitations.album_id', '=', 'albums.album_id')
     .select(
       'invitation_id',
       'invitations.user_id',
       'invited_user_id',
-      'album_id',
+      'invitations.album_id',
       'invitations.created_at',
-      'email as user_email',
-      'display_name as user_name'
+      'users.email as user_email',
+      'users.display_name as user_name',
+      'albums.title',
+      'albums.description',
+      'albums.cover_id'
     )
     .then(inviteArr => {
 

--- a/data/models/media.js
+++ b/data/models/media.js
@@ -586,7 +586,7 @@ const updateKeywords = (media_id, newKeywords, done) => {
             if (diff.remove.length) {
 
               console.log('dissociate after add', diff.remove);
-              removeAssociations(media_id, diff.remove, done);
+              removeKeywordAssociations(media_id, diff.remove, done);
 
             } else {
 
@@ -603,7 +603,7 @@ const updateKeywords = (media_id, newKeywords, done) => {
       } else if (diff.remove.length) {
 
         console.log('dissociate only', diff.remove);
-        removeAssociations(media_id, diff.remove, done);
+        removeKeywordAssociations(media_id, diff.remove, done);
 
       } else done(null);
 
@@ -700,7 +700,7 @@ const associateKeywords = (media_id, keywordsToAssociate, done) => {
 
 };
 
-const removeAssociations = (media_id, keywordsToDisassociate, done) => {
+const removeKeywordAssociations = (media_id, keywordsToDisassociate, done) => {
 
   const toRemove = keywordsToDisassociate.map(e => ({ media_id, keyword_id: e }));
   db('mediaKeywords').whereIn(toRemove)

--- a/data/models/media.js
+++ b/data/models/media.js
@@ -488,6 +488,20 @@ const retrieveUsersMedia = (user_id, done) => {
     }).catch(userIdErr => done(userIdErr));
 };
 
+const deleteAlbumMedia = (album_id, media_id, done) => {
+
+  return db('mediaAlbums').where({ album_id, media_id })
+    .del()
+    .then(deleted => {
+
+      if (!deleted) done (new Error(errors.mediaAlbumDoesNotExist));
+      else done(null, deleted);
+
+    })
+    .catch(mediaAlbumsErr => done(mediaAlbumsErr));
+
+};
+
 module.exports = {
   createMediaToAlbums,
   createMedia,
@@ -496,4 +510,5 @@ module.exports = {
   createManyMediaMeta,
   retrieveAlbumsMedia,
   retrieveUsersMedia,
+  deleteAlbumMedia,
 };

--- a/modules/errors.js
+++ b/modules/errors.js
@@ -54,6 +54,7 @@ module.exports = {
   invitationAlreadyexists: 'an invitation already exists',
   invitationDoesNotExist:  'invite id does not exist',
   alreadyCollaborator:     'user is already a collaborator',
-  collaboratorDoesNotExist: 'that collaborator does not exist'
+  collaboratorDoesNotExist: 'that collaborator does not exist',
+  mediaAlbumDoesNotExist:  'there is no media of that id in that album',
 
 };

--- a/modules/routes.js
+++ b/modules/routes.js
@@ -25,9 +25,11 @@ module.exports = {
   getAlbumsMedia: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/media`      : '/albums/:album_id/media'), // Send media that belongs to an album
   addAlbumsMedia: (user_id)  => (typeof user_id  !== 'undefined' ? `/users/${ user_id }/media/add`    : '/users/:user_id/media/add'),
   getUsersMedia:  (user_id)  => (typeof user_id  !== 'undefined' ? `/users/${ user_id }/media`        : '/users/:user_id/media'),   // Send media that belongs to a user.
-  removeMedia:    (user_id)  => (typeof user_id  !== 'undefined' ? `/users/${ user_id }/media/remove` : '/users/:user_id/media/remove'), // Contains an array of media IDs to delete. Only owner and admin can do this.
+  // removeMedia:    (user_id)  => (typeof user_id  !== 'undefined' ? `/users/${ user_id }/media/remove` : '/users/:user_id/media/remove'), // Contains an array of media IDs to delete. Only owner and admin can do this.
   viewUsersMedia: (user_id, title, type) => ((typeof user_id !== 'undefined' && typeof title !== 'undefined' && typeof type !== 'undefined') ? `/users/${ user_id }/media/${ type }/${ title }` : '/users/:user_id/media/:type/:title'),
   viewMedia:      (type, title) => (typeof title !== 'undefined' ? `/media/${ type }/${ title }` : '/media/:type/:title'),
+  editMedia:      () => ('/albums/:album_id/media/:media_id/edit'),
+  deleteMedia:    () => ('/albums/:album_id/media/:media_id/remove'),
   
   // Comments
   getAlbumsComments: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/comments` : '/albums/:album_id/comments'),


### PR DESCRIPTION
# Description

last minute routes to edit media, and its associated keywords and meta, and to delete associations between albums and media.

deleting media associations is very straightforward, and unlikely to run into significant bugs, and should be very easy to correct if it does.

editing the media object is pretty simple, though it should be noted that the title can't be changed at this time. It's stored on cloudinary under the title, and that association will break if the title changes.

editing the meta and keywords associated with a media object is quite a bit more complicated.
If either of those properties is falsy in the request, they'll simply assume that no changes were intended, and ignore them.

Otherwise, it will check the values in the request against the db. Values in the request, but not the db, will be added. Values in the db, but not the request, will be deleted. I did my best to test these features manually, but they're a bit complicated and may need some bug fixes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, ready to review and merge

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
