### PR TITLE
couple of minor bugs, route to get individual media objects

### DIFF
--- a/api/controllers/media.js
+++ b/api/controllers/media.js
@@ -332,6 +332,31 @@ const deleteMedia = (req, res, next) => {
 
 };
 
+const getMediaData = (req, res, next) => {
+
+  const { media_id } = req.params;
+
+  if (req.isAdmin || req.isOwner || req.isCollab) {
+
+    models.media.getMediaData(media_id, (mediaErr, mediaObj) => {
+
+      if (mediaErr) next(mediaErr);
+      else {
+
+        mediaObj.media_url = `${ serverHost }/users/${ mediaObj.user_id }/media/original/${ mediaObj.title }`;
+        mediaObj.thumbnail_url = `${ serverHost }/users/${ mediaObj.user_id }/media/thumbnail/${ mediaObj.title }`;
+
+        res.status(200).json(mediaObj);
+
+      }
+
+    });
+
+  } else next(new Error(errors.unauthorized));
+  
+
+};
+
 module.exports = {
   addAlbumsMedia,
   getAlbumsMedia,
@@ -340,4 +365,5 @@ module.exports = {
   viewMedia,
   editMedia,
   deleteMedia,
+  getMediaData,
 };

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -75,7 +75,6 @@ const verifyPermission = (req, res, next) => {
       case routes.getInvitesByAlbum():
       case routes.getCollaborators():
       case routes.deleteMedia():
-      case routes.editMedia():
         
         const album_id = parseInt(req.params.album_id);
 
@@ -241,6 +240,39 @@ const verifyPermission = (req, res, next) => {
         } else next(new Error(errors.unauthorized));
         break;
 
+      case routes.getMediaData():
+      case routes.editMedia():
+
+        if (email !== null) {
+
+          const media_id = parseInt(req.params.media_id);
+
+          models.user.retrieveUserBy({ email }, (userErr, userObj) => {
+
+            if (userErr) next(userErr);
+            else {
+
+              models.media.isOwnerOrCollaborator(media_id, userObj.user_id, (mediaErr, isOwner, isCollab) => {
+
+                if (mediaErr) next(mediaErr);
+                else {
+
+                  req.isAdmin = userObj.isAdmin;
+                  req.isOwner = isOwner;
+                  req.isCollab = isCollab;
+
+                  next();
+
+                }
+
+              });
+
+            }
+
+          });
+
+        } else next(new Error(errors.unauthorized));
+        break;
 
       default:
         next(new Error(errors.unauthorized));

--- a/api/routes/media.js
+++ b/api/routes/media.js
@@ -284,7 +284,7 @@ router.get(routes.getUsersMedia(), api.auth.verifyToken, api.auth.verifyPermissi
 // #region
 /**
  * 
- *  @api {put} /albums/:album_id/media/:media_id/edit Update a piece of media
+ *  @api {put} /media/data/:media_id/edit Update a piece of media
  *  @apiName edit-media
  *  @apiGroup Media
  *  @apiVersion 0.1.0
@@ -392,6 +392,70 @@ router.put(routes.editMedia(), api.auth.verifyToken, api.auth.verifyPermission, 
  */
 // #endregion
 router.delete(routes.deleteMedia(), api.auth.verifyToken, api.auth.verifyPermission, api.media.deleteMedia, sentryError);
+
+
+// HTTP/1.1 200 OK
+// #region
+/**
+ * 
+ *  @api {get} /media/data/:media_id/view get specifc media info
+ *  @apiName get-individual-media
+ *  @apiGroup Media
+ *  @apiVersion 0.1.0
+ * 
+ *  @apiPermission admin owner collaborator
+ * 
+ *  @apiHeader (Headers) {String} Authorization JWT for user auth
+ * 
+ *  @apiHeaderExample {json} Header Example
+ *     {
+ *          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw"
+ *     }
+ * 
+ *  @apiParam (URL Parameters) {Integer} media_id The media ID
+ * 
+ *  @apiParamExample {json} Example Request
+ *      /media/data/23545/view
+ * 
+ *  @apiSuccessExample {json} Example Response
+ *     HTTP/1.1 200 OK
+ * 
+ *   {
+ *     "media_id": 99,
+ *     "user_id": 222,
+ *     "title": "photo",
+ *     "caption": "a caption2",
+ *     "type": "photo",
+ *     "created_at": "2020-01-09 09:19:45",
+ *     "updated_at": "2020-01-12 05:02:39",
+ *     "keywords": ["keyword-one", "keyword-two", "keyword-three"],
+ *     "meta": {
+ *       "People": "Family",
+ *       "Meta Name": "Meta Value"
+ *     }
+ *     "media_url": "http://localhost:4000/users/222/media/original/photo",
+ *     "thumbnail_url": "http://localhost:4000/users/222/media/thumbnail/photo"
+ *   }
+ * 
+ *   @apiError {Object} userIdDoesNotExist The album ID does not exist in the database
+ *   @apiError {Object} unauthorized You are not authorized to make the request
+ *   @apiError {Object} serverError Internal server error
+ * 
+ *   @apiErrorExample Does Not Exists
+ *      HTTP/1.1 404
+ *      {
+ *          "userIdDoesNotExist": "album id does not exist"
+ *      }
+ * 
+ *   @apiErrorExample Server Error
+ *      HTTP/1.1 500
+ *      {
+ *          "serverError": "server error"
+ *      }
+ * 
+ */
+// #endregion
+router.get(routes.getMediaData(), api.auth.verifyToken, api.auth.verifyPermission, api.media.getMediaData, sentryError);
 
 // Route for serving users media from Cloudinary.
 router.get(routes.viewUsersMedia(), /* api.auth.verifyToken, api.auth.verifyPermission, */ api.media.viewUsersMedia, sentryError);

--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -2615,7 +2615,7 @@ define({ "api": [
   },
   {
     "type": "put",
-    "url": "/albums/:album_id/media/:media_id/edit",
+    "url": "/media/data/:media_id/edit",
     "title": "Update a piece of media",
     "name": "edit_media",
     "group": "Media",
@@ -2721,6 +2721,109 @@ define({ "api": [
         {
           "title": "Example Response",
           "content": "HTTP/1.1 200 OK\n{\n  \"edited_id\": 34532\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "get",
+    "url": "/media/data/:media_id/view",
+    "title": "get specifc media info",
+    "name": "get_individual_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/media/data/23545/view",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "  HTTP/1.1 200 OK\n\n{\n  \"media_id\": 99,\n  \"user_id\": 222,\n  \"title\": \"photo\",\n  \"caption\": \"a caption2\",\n  \"type\": \"photo\",\n  \"created_at\": \"2020-01-09 09:19:45\",\n  \"updated_at\": \"2020-01-12 05:02:39\",\n  \"keywords\": [\"keyword-one\", \"keyword-two\", \"keyword-three\"],\n  \"meta\": {\n    \"People\": \"Family\",\n    \"Meta Name\": \"Meta Value\"\n  }\n  \"media_url\": \"http://localhost:4000/users/222/media/original/photo\",\n  \"thumbnail_url\": \"http://localhost:4000/users/222/media/thumbnail/photo\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -2615,7 +2615,7 @@
   },
   {
     "type": "put",
-    "url": "/albums/:album_id/media/:media_id/edit",
+    "url": "/media/data/:media_id/edit",
     "title": "Update a piece of media",
     "name": "edit_media",
     "group": "Media",
@@ -2721,6 +2721,109 @@
         {
           "title": "Example Response",
           "content": "HTTP/1.1 200 OK\n{\n  \"edited_id\": 34532\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "userIdDoesNotExist",
+            "description": "<p>The album ID does not exist in the database</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "unauthorized",
+            "description": "<p>You are not authorized to make the request</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "serverError",
+            "description": "<p>Internal server error</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Does Not Exists",
+          "content": "HTTP/1.1 404\n{\n    \"userIdDoesNotExist\": \"album id does not exist\"\n}",
+          "type": "json"
+        },
+        {
+          "title": "Server Error",
+          "content": "HTTP/1.1 500\n{\n    \"serverError\": \"server error\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "api/routes/media.js",
+    "groupTitle": "Media"
+  },
+  {
+    "type": "get",
+    "url": "/media/data/:media_id/view",
+    "title": "get specifc media info",
+    "name": "get_individual_media",
+    "group": "Media",
+    "version": "0.1.0",
+    "permission": [
+      {
+        "name": "admin owner collaborator"
+      }
+    ],
+    "header": {
+      "fields": {
+        "Headers": [
+          {
+            "group": "Headers",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>JWT for user auth</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Header Example",
+          "content": "{\n     \"Authorization\": \"Bearer eyJhbGciOiJIUzI1NiIsInCI6IkpXVCJ9.eyJkaXNwbGF5X25hbWUiOeU5hbWUiLCJlbWFpbCI6Im15TmFtZUBtYWlsLmNvbSIsImlhdCI6MTMzQ0ODQ3OH0.XcgH1HUKKxcB80xVUWrLBELvO1D5RQ4azF6ibBw\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "parameter": {
+      "fields": {
+        "URL Parameters": [
+          {
+            "group": "URL Parameters",
+            "type": "Integer",
+            "optional": false,
+            "field": "media_id",
+            "description": "<p>The media ID</p>"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Example Request",
+          "content": "/media/data/23545/view",
+          "type": "json"
+        }
+      ]
+    },
+    "success": {
+      "examples": [
+        {
+          "title": "Example Response",
+          "content": "  HTTP/1.1 200 OK\n\n{\n  \"media_id\": 99,\n  \"user_id\": 222,\n  \"title\": \"photo\",\n  \"caption\": \"a caption2\",\n  \"type\": \"photo\",\n  \"created_at\": \"2020-01-09 09:19:45\",\n  \"updated_at\": \"2020-01-12 05:02:39\",\n  \"keywords\": [\"keyword-one\", \"keyword-two\", \"keyword-three\"],\n  \"meta\": {\n    \"People\": \"Family\",\n    \"Meta Name\": \"Meta Value\"\n  }\n  \"media_url\": \"http://localhost:4000/users/222/media/original/photo\",\n  \"thumbnail_url\": \"http://localhost:4000/users/222/media/thumbnail/photo\"\n}",
           "type": "json"
         }
       ]

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T10:54:37.118Z",
+    "time": "2020-01-13T08:57:27.480Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-01-12T10:54:37.118Z",
+    "time": "2020-01-13T08:57:27.480Z",
     "url": "http://apidocjs.com",
     "version": "0.19.0"
   }

--- a/modules/routes.js
+++ b/modules/routes.js
@@ -28,9 +28,10 @@ module.exports = {
   // removeMedia:    (user_id)  => (typeof user_id  !== 'undefined' ? `/users/${ user_id }/media/remove` : '/users/:user_id/media/remove'), // Contains an array of media IDs to delete. Only owner and admin can do this.
   viewUsersMedia: (user_id, title, type) => ((typeof user_id !== 'undefined' && typeof title !== 'undefined' && typeof type !== 'undefined') ? `/users/${ user_id }/media/${ type }/${ title }` : '/users/:user_id/media/:type/:title'),
   viewMedia:      (type, title) => (typeof title !== 'undefined' ? `/media/${ type }/${ title }` : '/media/:type/:title'),
-  editMedia:      () => ('/albums/:album_id/media/:media_id/edit'),
+  editMedia:      () => ('/media/data/:media_id/edit'),
   deleteMedia:    () => ('/albums/:album_id/media/:media_id/remove'),
-  
+  getMediaData:   () => ('/media/data/:media_id/view'),
+
   // Comments
   getAlbumsComments: (album_id) => (typeof album_id !== 'undefined' ? `/albums/${ album_id }/comments` : '/albums/:album_id/comments'),
 


### PR DESCRIPTION
# Description

add a route to get single media objects by id.
update the media editing route to no longer require or use an album_id. That was only ever there for auth purposes. Wrote a check in the auth middleware to sort that out without it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete,  ready to review and merge

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
